### PR TITLE
Align postgresql server/client versions mismatch when using devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,9 @@
 		},
 		"ghcr.io/devcontainers/features/node:1": {
 			"version": "latest"
+		},
+		"ghcr.io/rails/devcontainer/features/postgres-client:1.1.1": {
+			"version": "17"
 		}
 	},
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

When using devcontainer, postgresql server is at version 17.x - coming from docker image `postgres:latest` - while postgresql client version is 15.x - the one shipped in debian.

This makes `postgresql_rake_test.rb` fail as some postgresql "features" like `pg_dump` requires server/client to be at the same version.

### Detail

Adding devcontainer feature `ghcr.io/rails/devcontainer/features/postgres-client:1.1.1` fixed the version to `17` ensures `postgresql_rake_test.rb` is green when using devcontainers - at least untill a new postgresql version reaches `postgres:latest`.

### Additional information

This is the output of the failing test in devcontainer (which is green with this PR):
```bash
vscode ➜ /workspaces/rails/activerecord (main) $ ARCONN=postgresql bundle exec ruby -Itest test/cases/adapters/postgresql/postgresql_rake_test.rb
Using postgresql
Run options: --seed 14526

# Running:

..................pg_dump: error: aborting because of server version mismatch
pg_dump: detail: server version: 17.3 (Debian 17.3-1.pgdg120+1); pg_dump version: 15.10 (Debian 15.10-0+deb12u1)
E..................

Finished in 0.207234s, 178.5423 runs/s, 202.6696 assertions/s.

  1) Error:
ActiveRecord::PostgreSQLStructureDumpTest#test_structure_dump:
RuntimeError: failed to execute:
pg_dump --schema-only --no-privileges --no-owner --file /tmp/awesome-file.sql activerecord_unittest

Please check the output above for any errors and make sure that `pg_dump` is installed in your PATH and has proper permissions.


    lib/active_record/tasks/postgresql_database_tasks.rb:120:in 'ActiveRecord::Tasks::PostgreSQLDatabaseTasks#run_cmd'
    lib/active_record/tasks/postgresql_database_tasks.rb:75:in 'ActiveRecord::Tasks::PostgreSQLDatabaseTasks#structure_dump'
    lib/active_record/tasks/database_tasks.rb:366:in 'ActiveRecord::Tasks::DatabaseTasks#structure_dump'
    test/cases/adapters/postgresql/postgresql_rake_test.rb:341:in 'ActiveRecord::PostgreSQLStructureDumpTest#test_structure_dump'

37 runs, 42 assertions, 0 failures, 1 errors, 0 skips
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
